### PR TITLE
Feat: Implement 'cls' command using native OS calls

### DIFF
--- a/src/main/java/com/mycmd/App.java
+++ b/src/main/java/com/mycmd/App.java
@@ -106,7 +106,6 @@ public class App {
         commands.put("unalias", new UnaliasCommand());
         commands.put("rename", new RenameCommand());
         commands.put("set", new SetCommand());
-        commands.put("cls", new ClsCommand());
           }
 }
 


### PR DESCRIPTION
Hi! This PR adds the implementation for the `cls` command.

It uses `ProcessBuilder` to call the native OS command (`cls` on Windows, `clear` on macOS/Linux). This provides a true screen-clearing functionality as discussed in the issue.

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "cls" command for clearing the console screen
  * Implemented native OS-level clear-screen functionality supporting Windows and Unix-like systems
  * Enhanced error handling for clear-screen operations with improved interrupt signal management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->