### PR TITLE
Remove method duplication

### DIFF
--- a/src/main/java/com/mycmd/StringUtils.java
+++ b/src/main/java/com/mycmd/StringUtils.java
@@ -3,7 +3,7 @@ package com.mycmd;
 /** String helper functions for commands. */
 public class StringUtils {
   public static boolean isEmpty(String s) {
-    return s == null || s.isEmpty();
+    return s == null || s.isBlank();
   }
 
   public static String join(String[] arr, int start) {

--- a/src/main/java/com/mycmd/StringUtils.java
+++ b/src/main/java/com/mycmd/StringUtils.java
@@ -3,7 +3,7 @@ package com.mycmd;
 /** String helper functions for commands. */
 public class StringUtils {
   public static boolean isEmpty(String s) {
-    return s == null || s.trim().isEmpty();
+    return s == null || s.isEmpty();
   }
 
   public static String join(String[] arr, int start) {


### PR DESCRIPTION
Why use `trim()` and `isEmpty()` when it can be done using `isBlank()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace handling to correctly identify and treat whitespace-only strings as empty, with broader Unicode whitespace support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->